### PR TITLE
Two little fixes

### DIFF
--- a/EnvHelper.py
+++ b/EnvHelper.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 ############################################################################
-
+import time
 import os, tempfile, re, imp
 from subprocess import Popen, PIPE
 
@@ -31,7 +31,7 @@ class LimaCCDs(PyTango.Device_4Impl):
         PyTango.Device_4Impl.__init__(self,*args)
         self.get_device_properties(self.get_device_class())
         print 'LimaCameraType=%s' % self.LimaCameraType
-        sys.exit(0)
+        #sys.exit(0)
 
 class LimaCCDsClass(PyTango.DeviceClass):
     device_property_list = {
@@ -48,7 +48,7 @@ tango_util = PyTango.Util(sys.argv)
 tango_util.add_TgClass(LimaCCDsClass, LimaCCDs, 'LimaCCDs')
 tango_util_inst = PyTango.Util.instance()
 tango_util_inst.server_init()
-tango_util_inst.server_run()
+#tango_util_inst.server_run()
 """
 
 ModDepend = ['Core', 'Espia']
@@ -79,7 +79,8 @@ def setup_lima_env(argv):
         for l in pobj.stdout.readlines():
             key, val = l.strip().split('=')
             output[key] = val
-        pobj.wait()
+        while pobj.poll() is None:
+          time.sleep(0.1) 
         print_debug('Retry %d - got from TANGO database: %s' % (r, output))
         if 'LimaCameraType' in output.keys():
             break


### PR DESCRIPTION
- calling sys.exit in Tango device constructor always produces an error
- use 'poll' to know if child process is finished instead of 'wait',
  which is causing problems:

``` python
Traceback (most recent call last):
  File "LimaCCDs.py", line 58, in <module>
    LimaCameraType = setup_lima_env(sys.argv)
  File "/users/blissadm/applications/LimaCCDs/EnvHelper.py", line 83, in setup_lima_env
    pobj.wait()
  File "/users/blissadm/python/bliss_python/redhate4/lib/python2.6/subprocess.py", line 1157, in wait
    pid, sts = os.waitpid(self.pid, 0)
OSError: [Errno 10] No child processes
```
